### PR TITLE
Use Firebase CLI directly to deploy to App Distribution with Workload Identity Provider

### DIFF
--- a/.github/workflows/app_distribution.yml
+++ b/.github/workflows/app_distribution.yml
@@ -20,16 +20,17 @@ jobs:
     timeout-minutes: 10
     permissions:
       id-token: write
+      contents: read
     steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.branch }}
     - id: auth
-      uses: google-github-actions/auth@v0
+      uses: google-github-actions/auth@v1
       with:
         create_credentials_file: true
         workload_identity_provider: ${{ secrets.WORKFLOW_IDENTITY_PROVIDER }}
         service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.inputs.branch }}
     - name: set up JDK
       uses: actions/setup-java@v3
       with:
@@ -47,11 +48,15 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
+    - name: Prepare release notes
+      run: |
+        echo "${{ github.event.inputs.release_notes }}" >> release_notes.txt
+        echo "${{ github.event.inputs.branch }}@$(git rev-parse HEAD)" >> release_notes.txt
     - name: Deploy to Firebase App Distribution
       env:
-        RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
         GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
       run: |
+        npm install -g firebase-tools
         bundle exec fastlane android setup_for_ci
         bundle exec fastlane android deploy_to_firebase_app_distribution

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,13 +33,16 @@ platform :android do
   # To upload an aab, needs to link Google Play Account to your Firebase project, so upload an apk currently
   lane :deploy_to_firebase_app_distribution do
     gradle(task: "assembleDebug")
-    release_notes = ENV['RELEASE_NOTES'] || 'Deployed from GitHub Actions'
-    firebase_app_distribution(
-      app: ENV['FIREBASE_APP_ID'],
-      android_artifact_type: 'APK',
-      android_artifact_path: 'app/build/outputs/apk/debug/app-debug.apk',
-      release_notes: release_notes,
-      groups: 'tester'
+    sh(
+      'firebase',
+      'appdistribution:distribute',
+      '../app/build/outputs/apk/debug/app-debug.apk',
+      '--app',
+      ENV['FIREBASE_APP_ID'],
+      '--release-notes-file',
+      '../release_notes.txt',
+      '--groups',
+      'tester'
     )
   end
 


### PR DESCRIPTION
fix error: missing client_email when using app distribution Fastlane plugin